### PR TITLE
Limit associated item functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -152,6 +152,11 @@ pub enum ParserErrorKind {
         token: Option<Token>,
     },
 
+    ExtraTokens {
+        token: Option<Token>,
+        msg: String,
+    },
+
     TypeConversionError {
         type_a: String,
         type_b: String,
@@ -181,6 +186,10 @@ impl fmt::Display for ParserErrorKind {
 
             ParserErrorKind::InvalidTokenContext { token } => {
                 write!(f, "syntax error. Invalid token context – `{:#?}`", token)
+            }  
+            
+            ParserErrorKind::ExtraTokens { token, msg } => {
+                write!(f, "syntax error. Extra tokens detected – `{:#?}`. {msg}", token)
             }
 
             ParserErrorKind::TypeConversionError { type_a, type_b } => write!(

--- a/src/parser/function_item.rs
+++ b/src/parser/function_item.rs
@@ -62,7 +62,13 @@ impl ParseDefinition for FunctionItem {
         };
 
         let block_opt = if let Some(Token::LBrace { .. }) = parser.current_token() {
-            Some(BlockExpr::parse(parser)?)
+            if let Some(Token::RBrace { .. }) = parser.peek_ahead_by(1) {
+                parser.next_token();
+                parser.next_token();
+                None
+            } else {
+                Some(BlockExpr::parse(parser)?)
+            }
         } else {
             None
         };

--- a/src/parser/impl_def.rs
+++ b/src/parser/impl_def.rs
@@ -148,7 +148,15 @@ impl ParseAssociatedItem for InherentImplItem {
 
             Some(Token::Func { .. }) => {
                 let function_def = FunctionItem::parse(parser, attributes_opt, visibility)?;
-                Ok(InherentImplItem::FunctionDef(function_def))
+                if function_def.block_opt.is_none() {
+                    parser.log_error(crate::error::ParserErrorKind::ExtraTokens {
+                        token: parser.current_token(),
+                        msg: "Functions in implementation blocks must have bodies".to_string(),
+                    });
+                    Err(ErrorsEmitted)
+                } else {
+                    Ok(InherentImplItem::FunctionDef(function_def))
+                }
             }
             _ => {
                 parser.log_unexpected_token("`const` or `func`");
@@ -183,7 +191,15 @@ impl ParseAssociatedItem for TraitImplItem {
             }
             Some(Token::Func { .. }) => {
                 let function_def = FunctionItem::parse(parser, attributes_opt, visibility)?;
-                Ok(TraitImplItem::FunctionDef(function_def))
+                if function_def.block_opt.is_none() {
+                    parser.log_error(crate::error::ParserErrorKind::ExtraTokens {
+                        token: parser.current_token(),
+                        msg: "Functions in implementation blocks must have bodies".to_string(),
+                    });
+                    Err(ErrorsEmitted)
+                } else {
+                    Ok(TraitImplItem::FunctionDef(function_def))
+                }
             }
             _ => {
                 parser.log_unexpected_token("`const`, `alias` or `func`");

--- a/src/parser/trait_def.rs
+++ b/src/parser/trait_def.rs
@@ -83,7 +83,15 @@ impl ParseAssociatedItem for TraitDefItem {
             }
             Some(Token::Func { .. }) => {
                 let function_def = FunctionItem::parse(parser, attributes_opt, visibility)?;
-                Ok(TraitDefItem::FunctionDef(function_def))
+                if function_def.block_opt.is_some() {
+                    parser.log_error(crate::error::ParserErrorKind::ExtraTokens {
+                        token: parser.current_token(),
+                        msg: "Functions in trait definitions cannot have bodies".to_string(),
+                    });
+                    Err(ErrorsEmitted)
+                } else {
+                    Ok(TraitDefItem::FunctionDef(function_def))
+                }
             }
             _ => {
                 parser.log_unexpected_token("`const`, `alias` or `func`");


### PR DESCRIPTION
Adjust `InherentImplItem` and `TraitImplItem` parsing functions so that their `FunctionItem` associated items must have bodies, and the opposite for `TraitDefItem` 