### PR TITLE
Add assignee expression helpers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -339,7 +339,7 @@ pub enum AssigneeExpr {
     UnderscoreExpr(UnderscoreExpr),
     SliceExpr(Vec<AssigneeExpr>),
     TupleExpr(Vec<AssigneeExpr>),
-    StructExpr(Vec<(Identifier, AssigneeExpr)>),
+    StructExpr(Vec<StructAssigneeExprField>),
     // TupleStructExpr(Vec<AssigneeExpr>),
 }
 
@@ -389,14 +389,21 @@ impl TryFrom<Expression> for AssigneeExpr {
             }
 
             Expression::Struct(s) => {
-                let mut assignee_expressions: Vec<(Identifier, AssigneeExpr)> = Vec::new();
+                let mut assignee_expressions: Vec<StructAssigneeExprField> = Vec::new();
 
                 s.fields_opt.map(|v| {
                     v.into_iter().for_each(|s| {
-                        let value = AssigneeExpr::try_from(s.field_value).expect(
+                        let attributes_opt = s.attributes_opt;
+                        let field_value = AssigneeExpr::try_from(s.field_value).expect(
                             "conversion error: unable to convert `Expression` into `AssigneeExpr`",
                         );
-                        assignee_expressions.push((s.field_name, value));
+
+                        let struct_assignee_expr_field = StructAssigneeExprField {
+                            attributes_opt,
+                            field_name: s.field_name,
+                            field_value,
+                        };
+                        assignee_expressions.push(struct_assignee_expr_field);
                     })
                 });
 

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -49,11 +49,24 @@ pub struct StructField {
     pub field_value: Expression,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructAssigneeExprField {
+    pub attributes_opt: Option<Vec<OuterAttr>>,
+    pub field_name: Identifier,
+    pub field_value: AssigneeExpr,
+}
+
 /// Struct representing a collection of elements in a tuple expression.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TupleElements {
     pub elements: Vec<(Expression, Separator)>, // single-element tuple must have trailing comma
     pub final_element_opt: Option<Box<Expression>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TupleAssigneeExprElements {
+    pub elements: Vec<(AssigneeExpr, Separator)>,
+    pub final_element_opt: Option<Box<AssigneeExpr>>,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -63,12 +63,6 @@ pub struct TupleElements {
     pub final_element_opt: Option<Box<Expression>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct TupleAssigneeExprElements {
-    pub elements: Vec<(AssigneeExpr, Separator)>,
-    pub final_element_opt: Option<Box<AssigneeExpr>>,
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // AST NODE STRUCTURES
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add `StructAssigneeExprField` helper type to help create structs with `AssigneeExpr`