### PR TITLE
Update `current_token()` function

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -280,7 +280,7 @@ impl Parser {
         self.log_current_token(true);
         ////////////////////////////////////////////////////////////////////////////////
 
-        match &self.current_token() {
+        match self.current_token() {
             Some(Token::Identifier { .. }) => Ok(Expression::Path(PathExpr::parse(self)?)),
             Some(Token::IntLiteral { value, .. }) => Ok(Expression::Literal(Literal::Int(*value))),
             Some(Token::UIntLiteral { value, .. }) => {
@@ -357,8 +357,8 @@ impl Parser {
                         underscore: Identifier::from(name),
                     }))
                 } else {
-                    match &self.peek_ahead_by(1) {
-                        Some(Token::LBrace { .. }) => match &self.peek_behind_by(1) {
+                    match self.peek_ahead_by(1) {
+                        Some(Token::LBrace { .. }) => match self.peek_behind_by(1) {
                             Some(
                                 Token::Equals { .. }
                                 | Token::LParen { .. }
@@ -381,7 +381,7 @@ impl Parser {
                 }
             }
             Some(Token::SelfType { .. }) => {
-                if let Some(Token::LBrace { .. }) = &self.peek_ahead_by(1) {
+                if let Some(Token::LBrace { .. }) = self.peek_ahead_by(1) {
                     Ok(Expression::Struct(StructExpr::parse(self)?))
                 } else {
                     Ok(Expression::Path(PathExpr::parse(self)?))
@@ -426,16 +426,16 @@ impl Parser {
             Some(Token::Unsafe { .. }) => Ok(Expression::Block(BlockExpr::parse(self)?)),
 
             Some(Token::LParen { .. }) => {
-                if let Some(Token::Comma { .. }) = &self.peek_ahead_by(2) {
+                if let Some(Token::Comma { .. }) = self.peek_ahead_by(2) {
                     Ok(Expression::Tuple(TupleExpr::parse(self)?))
                 } else {
                     self.parse_primary()
                 }
             }
 
-            Some(Token::LBrace { .. }) => match &self.peek_ahead_by(2) {
+            Some(Token::LBrace { .. }) => match self.peek_ahead_by(2) {
                 Some(Token::Colon { .. }) => Ok(Expression::Mapping(MappingExpr::parse(self)?)),
-                _ => match &self.peek_ahead_by(1) {
+                _ => match self.peek_ahead_by(1) {
                     Some(Token::RBrace { .. }) => {
                         Ok(Expression::Mapping(MappingExpr::parse(self)?))
                     }
@@ -475,7 +475,7 @@ impl Parser {
                 }
             }
 
-            Some(Token::DblDot { .. }) => match (&self.peek_behind_by(1), &self.peek_ahead_by(1)) {
+            Some(Token::DblDot { .. }) => match (self.peek_behind_by(1), self.peek_ahead_by(1)) {
                 (None, Some(Token::Semicolon { .. } | Token::EOF) | None) => {
                     let expr = RangeExpr {
                         from_expr_opt: None,
@@ -576,7 +576,7 @@ impl Parser {
 
                 self.next_token();
 
-                match &self.current_token() {
+                match self.current_token() {
                     Some(Token::EOF) | None => {
                         self.log_unexpected_eoi();
                         return Err(ErrorsEmitted);
@@ -743,7 +743,7 @@ impl Parser {
 
         let visibility = Visibility::visibility(self)?;
 
-        match &self.current_token() {
+        match self.current_token() {
             Some(Token::Import { .. }) => {
                 let import_decl = ImportDecl::parse(self, attributes_opt, visibility)?;
                 Ok(Item::ImportDecl(import_decl))
@@ -772,7 +772,7 @@ impl Parser {
                 let enum_def = EnumDef::parse(self, attributes_opt, visibility)?;
                 Ok(Item::EnumDef(enum_def))
             }
-            Some(Token::Struct { .. }) => match &self.peek_ahead_by(2) {
+            Some(Token::Struct { .. }) => match self.peek_ahead_by(2) {
                 Some(Token::LBrace { .. }) => {
                     let struct_def = StructDef::parse(self, attributes_opt, visibility)?;
                     Ok(Item::StructDef(struct_def))
@@ -787,7 +787,7 @@ impl Parser {
                 }
             },
             Some(Token::Impl { .. }) => {
-                if let Some(Token::For { .. }) = &self.peek_ahead_by(2) {
+                if let Some(Token::For { .. }) = self.peek_ahead_by(2) {
                     Ok(Item::TraitImplDef(TraitImplDef::parse(
                         self,
                         attributes_opt,
@@ -827,7 +827,7 @@ impl Parser {
         self.log_current_token(false);
         ////////////////////////////////////////////////////////////////////////////////
 
-        match &self.current_token() {
+        match self.current_token() {
             Some(Token::Let { .. }) => LetStmt::parse_statement(self),
 
             Some(
@@ -870,7 +870,7 @@ impl Parser {
                     self.parse_expression(Precedence::Lowest)?,
                 ));
 
-                match &self.current_token() {
+                match self.current_token() {
                     Some(Token::Semicolon { .. }) => {
                         self.next_token();
                     }
@@ -906,7 +906,7 @@ impl Parser {
                 let patt = Pattern::Literal(Literal::Int(*value));
 
                 if let Some(Token::DblDot { .. } | Token::DotDotEquals { .. }) =
-                    &self.peek_ahead_by(1)
+                    self.peek_ahead_by(1)
                 {
                     Ok(Pattern::RangePatt(RangePatt::parse_patt(self)?))
                 } else {
@@ -918,7 +918,7 @@ impl Parser {
                 let patt = Pattern::Literal(Literal::UInt(*value));
 
                 if let Some(Token::DblDot { .. } | Token::DotDotEquals { .. }) =
-                    &self.peek_ahead_by(1)
+                    self.peek_ahead_by(1)
                 {
                     Ok(Pattern::RangePatt(RangePatt::parse_patt(self)?))
                 } else {
@@ -931,7 +931,7 @@ impl Parser {
                 let patt = Pattern::Literal(Literal::BigUInt(*value));
 
                 if let Some(Token::DblDot { .. } | Token::DotDotEquals { .. }) =
-                    &self.peek_ahead_by(1)
+                    self.peek_ahead_by(1)
                 {
                     Ok(Pattern::RangePatt(RangePatt::parse_patt(self)?))
                 } else {
@@ -943,7 +943,7 @@ impl Parser {
                 let patt = Pattern::Literal(Literal::Byte(*value));
 
                 if let Some(Token::DblDot { .. } | Token::DotDotEquals { .. }) =
-                    &self.peek_ahead_by(1)
+                    self.peek_ahead_by(1)
                 {
                     Ok(Pattern::RangePatt(RangePatt::parse_patt(self)?))
                 } else {
@@ -968,7 +968,7 @@ impl Parser {
                 let patt = Pattern::Literal(Literal::Char(*value));
 
                 if let Some(Token::DblDot { .. } | Token::DotDotEquals { .. }) =
-                    &self.peek_ahead_by(1)
+                    self.peek_ahead_by(1)
                 {
                     Ok(Pattern::RangePatt(RangePatt::parse_patt(self)?))
                 } else {
@@ -981,7 +981,7 @@ impl Parser {
                 Ok(Pattern::Literal(Literal::Bool(*value)))
             }
             Some(Token::LParen { .. }) => {
-                if let Some(Token::Comma { .. }) = &self.peek_ahead_by(2) {
+                if let Some(Token::Comma { .. }) = self.peek_ahead_by(2) {
                     Ok(Pattern::TuplePatt(TuplePatt::parse_patt(self)?))
                 } else {
                     let patt = GroupedPatt::parse_patt(self)?;
@@ -996,7 +996,7 @@ impl Parser {
                         underscore: Identifier::from(name),
                     }))
                 } else {
-                    match &self.peek_ahead_by(1) {
+                    match self.peek_ahead_by(1) {
                         Some(Token::LBrace { .. }) => {
                             Ok(Pattern::StructPatt(StructPatt::parse_patt(self)?))
                         }
@@ -1018,7 +1018,7 @@ impl Parser {
                 Ok(Pattern::IdentifierPatt(IdentifierPatt::parse_patt(self)?))
             }
 
-            Some(Token::SelfType { .. }) => match &self.peek_ahead_by(1) {
+            Some(Token::SelfType { .. }) => match self.peek_ahead_by(1) {
                 Some(Token::LBrace { .. }) => {
                     Ok(Pattern::StructPatt(StructPatt::parse_patt(self)?))
                 }
@@ -1323,7 +1323,7 @@ impl Parser {
 
     /// Get the precedence of the current token to be compared and consumed.
     fn peek_precedence(&self) -> Precedence {
-        self.get_precedence(&self.current_token().unwrap())
+        self.get_precedence(self.current_token().unwrap())
     }
 
     /// Get the current token's position in the token stream, formatted to include line

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,7 +237,7 @@ impl Parser {
             LogLevel::Debug,
             LogMsg::from(format!(
                 "entering `parse_expression()` with precedence: {:?}",
-                precedence
+                &precedence
             )),
         );
         self.log_current_token(true);

--- a/src/parser/attribute.rs
+++ b/src/parser/attribute.rs
@@ -7,7 +7,7 @@ use super::Parser;
 
 impl InnerAttr {
     pub(crate) fn inner_attr(parser: &Parser) -> Option<InnerAttr> {
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Abstract { .. }) => Some(InnerAttr::Abstract),
             Some(Token::Contract { .. }) => Some(InnerAttr::Contract),
             Some(Token::Library { .. }) => Some(InnerAttr::Library),
@@ -21,7 +21,7 @@ impl InnerAttr {
 
 impl OuterAttr {
     pub(crate) fn outer_attr(parser: &Parser) -> Option<OuterAttr> {
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Calldata { .. }) => Some(OuterAttr::Calldata),
             Some(Token::Constructor { .. }) => Some(OuterAttr::Constructor),
             Some(Token::Error { .. }) => Some(OuterAttr::Error),

--- a/src/parser/attribute.rs
+++ b/src/parser/attribute.rs
@@ -7,7 +7,7 @@ use super::Parser;
 
 impl InnerAttr {
     pub(crate) fn inner_attr(parser: &Parser) -> Option<InnerAttr> {
-        match parser.current_token().as_ref() {
+        match &parser.current_token() {
             Some(Token::Abstract { .. }) => Some(InnerAttr::Abstract),
             Some(Token::Contract { .. }) => Some(InnerAttr::Contract),
             Some(Token::Library { .. }) => Some(InnerAttr::Library),
@@ -21,7 +21,7 @@ impl InnerAttr {
 
 impl OuterAttr {
     pub(crate) fn outer_attr(parser: &Parser) -> Option<OuterAttr> {
-        match parser.current_token().as_ref() {
+        match &parser.current_token() {
             Some(Token::Calldata { .. }) => Some(OuterAttr::Calldata),
             Some(Token::Constructor { .. }) => Some(OuterAttr::Constructor),
             Some(Token::Error { .. }) => Some(OuterAttr::Error),

--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -20,16 +20,16 @@ pub(crate) fn get_collection<T>(
     match open_delimiter {
         Delimiter::LParen { .. } => {
             while !matches!(
-                parser.current_token().as_ref(),
+                &parser.current_token(),
                 Some(Token::RParen { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+                if let Some(Token::Comma { .. }) = &parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    parser.current_token().as_ref(),
+                    &parser.current_token(),
                     Some(Token::RParen { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `)`");
@@ -40,16 +40,16 @@ pub(crate) fn get_collection<T>(
 
         Delimiter::LBrace { .. } => {
             while !matches!(
-                parser.current_token().as_ref(),
+                &parser.current_token(),
                 Some(Token::RBrace { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+                if let Some(Token::Comma { .. }) = &parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    parser.current_token().as_ref(),
+                    &parser.current_token(),
                     Some(Token::RBrace { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `}`");
@@ -60,18 +60,18 @@ pub(crate) fn get_collection<T>(
 
         Delimiter::Pipe { .. } => {
             while !matches!(
-                parser.current_token().as_ref(),
+                &parser.current_token(),
                 Some(Token::Pipe { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+                if let Some(Token::Comma { .. }) = &parser.current_token() {
                     parser.next_token();
-                } else if let Some(Token::Pipe { .. }) = parser.current_token().as_ref() {
+                } else if let Some(Token::Pipe { .. }) = &parser.current_token() {
                     break;
                 } else if !matches!(
-                    parser.current_token().as_ref(),
+                    &parser.current_token(),
                     Some(Token::Pipe { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `|`");
@@ -113,16 +113,16 @@ pub(crate) fn get_expressions(
     match open_delimiter {
         Delimiter::LParen { .. } => {
             while !matches!(
-                parser.current_token().as_ref(),
+                &parser.current_token(),
                 Some(Token::RParen { .. } | Token::EOF),
             ) {
                 let expr = parser.parse_expression(precedence)?;
                 expressions.push(expr);
 
-                if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+                if let Some(Token::Comma { .. }) = &parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    parser.current_token().as_ref(),
+                    &parser.current_token(),
                     Some(Token::RParen { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `)`");
@@ -132,16 +132,16 @@ pub(crate) fn get_expressions(
         }
         Delimiter::LBracket { .. } => {
             while !matches!(
-                parser.current_token().as_ref(),
+                &parser.current_token(),
                 Some(Token::RBracket { .. } | Token::EOF),
             ) {
                 let expr = parser.parse_expression(precedence)?;
                 expressions.push(expr);
 
-                if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+                if let Some(Token::Comma { .. }) = &parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    parser.current_token().as_ref(),
+                    &parser.current_token(),
                     Some(Token::RBracket { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `]`");
@@ -164,7 +164,7 @@ pub(crate) fn get_expressions(
         LogLevel::Debug,
         LogMsg::from(format!(
             "expressions.is_empty(): {}",
-            expressions.is_empty()
+            &expressions.is_empty()
         )),
     );
     parser.log_current_token(false);
@@ -185,7 +185,7 @@ pub(crate) fn get_associated_items<T: ParseAssociatedItem>(
     let mut items: Vec<T> = Vec::new();
 
     while !matches!(
-        parser.current_token().as_ref(),
+        &parser.current_token(),
         Some(Token::RBrace { .. } | Token::EOF)
     ) {
         let attributes_opt = get_attributes(parser, OuterAttr::outer_attr);
@@ -228,7 +228,7 @@ pub(crate) fn get_attributes<T>(
         .log(LogLevel::Debug, LogMsg::from("exiting `get_attributes()`"));
     parser.logger.log(
         LogLevel::Debug,
-        LogMsg::from(format!("attributes.is_empty(): {}", attributes.is_empty())),
+        LogMsg::from(format!("attributes.is_empty(): {}", &attributes.is_empty())),
     );
     parser.log_current_token(false);
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -20,16 +20,16 @@ pub(crate) fn get_collection<T>(
     match open_delimiter {
         Delimiter::LParen { .. } => {
             while !matches!(
-                &parser.current_token(),
+                parser.current_token(),
                 Some(Token::RParen { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = &parser.current_token() {
+                if let Some(Token::Comma { .. }) = parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    &parser.current_token(),
+                    parser.current_token(),
                     Some(Token::RParen { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `)`");
@@ -40,16 +40,16 @@ pub(crate) fn get_collection<T>(
 
         Delimiter::LBrace { .. } => {
             while !matches!(
-                &parser.current_token(),
+                parser.current_token(),
                 Some(Token::RBrace { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = &parser.current_token() {
+                if let Some(Token::Comma { .. }) = parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    &parser.current_token(),
+                    parser.current_token(),
                     Some(Token::RBrace { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `}`");
@@ -60,18 +60,18 @@ pub(crate) fn get_collection<T>(
 
         Delimiter::Pipe { .. } => {
             while !matches!(
-                &parser.current_token(),
+                parser.current_token(),
                 Some(Token::Pipe { .. } | Token::EOF),
             ) {
                 let item = f(parser)?;
                 collection.push(item);
 
-                if let Some(Token::Comma { .. }) = &parser.current_token() {
+                if let Some(Token::Comma { .. }) = parser.current_token() {
                     parser.next_token();
-                } else if let Some(Token::Pipe { .. }) = &parser.current_token() {
+                } else if let Some(Token::Pipe { .. }) = parser.current_token() {
                     break;
                 } else if !matches!(
-                    &parser.current_token(),
+                    parser.current_token(),
                     Some(Token::Pipe { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `|`");
@@ -113,16 +113,16 @@ pub(crate) fn get_expressions(
     match open_delimiter {
         Delimiter::LParen { .. } => {
             while !matches!(
-                &parser.current_token(),
+                parser.current_token(),
                 Some(Token::RParen { .. } | Token::EOF),
             ) {
                 let expr = parser.parse_expression(precedence)?;
                 expressions.push(expr);
 
-                if let Some(Token::Comma { .. }) = &parser.current_token() {
+                if let Some(Token::Comma { .. }) = parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    &parser.current_token(),
+                    parser.current_token(),
                     Some(Token::RParen { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `)`");
@@ -132,16 +132,16 @@ pub(crate) fn get_expressions(
         }
         Delimiter::LBracket { .. } => {
             while !matches!(
-                &parser.current_token(),
+                parser.current_token(),
                 Some(Token::RBracket { .. } | Token::EOF),
             ) {
                 let expr = parser.parse_expression(precedence)?;
                 expressions.push(expr);
 
-                if let Some(Token::Comma { .. }) = &parser.current_token() {
+                if let Some(Token::Comma { .. }) = parser.current_token() {
                     parser.next_token();
                 } else if !matches!(
-                    &parser.current_token(),
+                    parser.current_token(),
                     Some(Token::RBracket { .. } | Token::EOF)
                 ) {
                     parser.log_unexpected_token("`,` or `]`");
@@ -185,7 +185,7 @@ pub(crate) fn get_associated_items<T: ParseAssociatedItem>(
     let mut items: Vec<T> = Vec::new();
 
     while !matches!(
-        &parser.current_token(),
+        parser.current_token(),
         Some(Token::RBrace { .. } | Token::EOF)
     ) {
         let attributes_opt = get_attributes(parser, OuterAttr::outer_attr);

--- a/src/parser/expr/assignment_expr.rs
+++ b/src/parser/expr/assignment_expr.rs
@@ -15,7 +15,7 @@ impl ParseOperatorExpr for AssignmentExpr {
             ErrorsEmitted
         })?;
 
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let assignment_op = match operator_token {
             Token::Equals { .. } => {
@@ -32,7 +32,7 @@ impl ParseOperatorExpr for AssignmentExpr {
             }
         }?;
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         let rhs = parser.parse_value_expr(precedence)?;
 
@@ -53,7 +53,7 @@ impl ParseOperatorExpr for CompoundAssignmentExpr {
             ErrorsEmitted
         })?;
 
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let compound_assignment_op = match operator_token.token_type() {
             TokenType::PlusEquals => Ok(CompoundAssignmentOp::AddAssign),
@@ -71,7 +71,7 @@ impl ParseOperatorExpr for CompoundAssignmentExpr {
 
         parser.next_token();
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         let rhs = parser.parse_value_expr(precedence)?;
 

--- a/src/parser/expr/binary_expr.rs
+++ b/src/parser/expr/binary_expr.rs
@@ -26,7 +26,7 @@ impl ParseOperatorExpr for BinaryExpr {
             ErrorsEmitted
         })?;
 
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let binary_op = match operator_token.token_type() {
             TokenType::Plus => Ok(BinaryOp::Add),
@@ -48,7 +48,7 @@ impl ParseOperatorExpr for BinaryExpr {
             }
         }?;
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         parser.next_token();
 
@@ -81,7 +81,7 @@ impl ParseOperatorExpr for ComparisonExpr {
             ErrorsEmitted
         })?;
 
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let comparison_op = match operator_token.token_type() {
             TokenType::DblEquals => Ok(ComparisonOp::Equal),
@@ -98,7 +98,7 @@ impl ParseOperatorExpr for ComparisonExpr {
             }
         }?;
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         parser.next_token();
 

--- a/src/parser/expr/block_expr.rs
+++ b/src/parser/expr/block_expr.rs
@@ -90,7 +90,7 @@ fn parse_statements(parser: &mut Parser) -> Result<Option<Vec<Statement>>, Error
     );
     parser.logger.log(
         LogLevel::Debug,
-        LogMsg::from(format!("statements.is_empty(): {}", statements.is_empty())),
+        LogMsg::from(format!("statements.is_empty(): {}", &statements.is_empty())),
     );
     parser.log_current_token(false);
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/parser/expr/field_access_expr.rs
+++ b/src/parser/expr/field_access_expr.rs
@@ -12,13 +12,13 @@ impl ParseOperatorExpr for FieldAccessExpr {
             ErrorsEmitted
         })?;
 
-        let expr = match &parser.current_token().cloned() {
+        let expr = match parser.current_token().cloned() {
             Some(Token::Identifier { name, .. }) => {
                 parser.next_token();
 
                 Ok(FieldAccessExpr {
                     object: Box::new(object),
-                    field_name: Identifier::from(name),
+                    field_name: Identifier(name),
                 })
             }
             Some(Token::EOF) | None => {

--- a/src/parser/expr/field_access_expr.rs
+++ b/src/parser/expr/field_access_expr.rs
@@ -12,13 +12,13 @@ impl ParseOperatorExpr for FieldAccessExpr {
             ErrorsEmitted
         })?;
 
-        let expr = match parser.current_token() {
+        let expr = match &parser.current_token().cloned() {
             Some(Token::Identifier { name, .. }) => {
                 parser.next_token();
 
                 Ok(FieldAccessExpr {
                     object: Box::new(object),
-                    field_name: Identifier(name),
+                    field_name: Identifier::from(name),
                 })
             }
             Some(Token::EOF) | None => {

--- a/src/parser/expr/method_call_expr.rs
+++ b/src/parser/expr/method_call_expr.rs
@@ -12,10 +12,10 @@ impl ParseOperatorExpr for MethodCallExpr {
             ErrorsEmitted
         })?;
 
-        let method_name = match parser.current_token() {
+        let method_name = match &parser.current_token().cloned() {
             Some(Token::Identifier { name, .. }) => {
                 parser.next_token();
-                Ok(Identifier(name))
+                Ok(Identifier::from(name))
             }
             Some(Token::EOF) | None => {
                 parser.log_missing_token("identifier");
@@ -27,7 +27,7 @@ impl ParseOperatorExpr for MethodCallExpr {
             }
         }?;
 
-        let open_paren = match parser.current_token() {
+        let open_paren = match &parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -45,7 +45,7 @@ impl ParseOperatorExpr for MethodCallExpr {
 
         let args_opt = collection::get_expressions(parser, Precedence::Lowest, &open_paren)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
 

--- a/src/parser/expr/method_call_expr.rs
+++ b/src/parser/expr/method_call_expr.rs
@@ -12,10 +12,10 @@ impl ParseOperatorExpr for MethodCallExpr {
             ErrorsEmitted
         })?;
 
-        let method_name = match &parser.current_token().cloned() {
+        let method_name = match parser.current_token().cloned() {
             Some(Token::Identifier { name, .. }) => {
                 parser.next_token();
-                Ok(Identifier::from(name))
+                Ok(Identifier(name))
             }
             Some(Token::EOF) | None => {
                 parser.log_missing_token("identifier");
@@ -27,7 +27,7 @@ impl ParseOperatorExpr for MethodCallExpr {
             }
         }?;
 
-        let open_paren = match &parser.current_token() {
+        let open_paren = match parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -45,7 +45,7 @@ impl ParseOperatorExpr for MethodCallExpr {
 
         let args_opt = collection::get_expressions(parser, Precedence::Lowest, &open_paren)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
 

--- a/src/parser/expr/path_expr.rs
+++ b/src/parser/expr/path_expr.rs
@@ -18,9 +18,9 @@ impl ParseSimpleExpr for PathExpr {
 
         let mut tree: Vec<Identifier> = Vec::new();
 
-        let path_root = match parser.current_token() {
+        let path_root = match &parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
-                Ok(PathRoot::Identifier(Identifier::from(&name)))
+                Ok(PathRoot::Identifier(Identifier::from(name)))
             }
             Some(Token::SelfKeyword { .. }) => Ok(PathRoot::SelfKeyword),
             Some(Token::SelfType { .. }) => Ok(PathRoot::SelfType(SelfType)),
@@ -36,13 +36,13 @@ impl ParseSimpleExpr for PathExpr {
 
         parser.next_token();
 
-        while let Some(Token::DblColon { .. }) = parser.current_token() {
-            match parser.peek_ahead_by(1) {
+        while let Some(Token::DblColon { .. }) = &parser.current_token() {
+            match &parser.peek_ahead_by(1).cloned() {
                 Some(Token::Identifier { name, .. }) => {
                     parser.next_token();
                     parser.next_token();
 
-                    tree.push(Identifier(name));
+                    tree.push(Identifier::from(name));
                 }
                 Some(Token::LBrace { .. }) => break,
                 Some(Token::EOF) | None => {

--- a/src/parser/expr/path_expr.rs
+++ b/src/parser/expr/path_expr.rs
@@ -18,7 +18,7 @@ impl ParseSimpleExpr for PathExpr {
 
         let mut tree: Vec<Identifier> = Vec::new();
 
-        let path_root = match &parser.current_token() {
+        let path_root = match parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
                 Ok(PathRoot::Identifier(Identifier::from(name)))
             }
@@ -36,13 +36,13 @@ impl ParseSimpleExpr for PathExpr {
 
         parser.next_token();
 
-        while let Some(Token::DblColon { .. }) = &parser.current_token() {
-            match &parser.peek_ahead_by(1).cloned() {
+        while let Some(Token::DblColon { .. }) = parser.current_token() {
+            match parser.peek_ahead_by(1).cloned() {
                 Some(Token::Identifier { name, .. }) => {
                     parser.next_token();
                     parser.next_token();
 
-                    tree.push(Identifier::from(name));
+                    tree.push(Identifier(name));
                 }
                 Some(Token::LBrace { .. }) => break,
                 Some(Token::EOF) | None => {

--- a/src/parser/expr/range_expr.rs
+++ b/src/parser/expr/range_expr.rs
@@ -12,7 +12,7 @@ impl ParseOperatorExpr for RangeExpr {
             ErrorsEmitted
         })?;
 
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let range_op = match operator_token.token_type() {
             TokenType::DblDot => Ok(RangeOp::RangeExclusive),
@@ -33,7 +33,7 @@ impl ParseOperatorExpr for RangeExpr {
 
         parser.next_token();
 
-        if let Some(Token::EOF) = parser.current_token() {
+        if let Some(Token::EOF) = &parser.current_token() {
             let expr = RangeExpr {
                 from_expr_opt: Some(Box::new(from_assignee_expr)),
                 range_op: {
@@ -53,7 +53,7 @@ impl ParseOperatorExpr for RangeExpr {
             return Ok(Expression::Range(expr));
         }
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         let to_assignee_expr = parser.parse_assignee_expr(precedence)?;
 
@@ -69,7 +69,7 @@ impl ParseOperatorExpr for RangeExpr {
 
 impl RangeExpr {
     pub(crate) fn parse_prefix(parser: &mut Parser) -> Result<RangeExpr, ErrorsEmitted> {
-        let operator_token = parser.current_token().unwrap_or(Token::EOF);
+        let operator_token = &parser.current_token().cloned().unwrap_or(Token::EOF);
 
         let range_op = match operator_token {
             Token::DblDot { .. } => Ok(RangeOp::RangeExclusive),
@@ -106,7 +106,7 @@ impl RangeExpr {
             return Ok(expr);
         }
 
-        let precedence = parser.get_precedence(&operator_token);
+        let precedence = parser.get_precedence(operator_token);
 
         let to_assignee_expr = parser.parse_assignee_expr(precedence)?;
 

--- a/src/parser/expr/range_expr.rs
+++ b/src/parser/expr/range_expr.rs
@@ -33,7 +33,7 @@ impl ParseOperatorExpr for RangeExpr {
 
         parser.next_token();
 
-        if let Some(Token::EOF) = &parser.current_token() {
+        if let Some(Token::EOF) = parser.current_token() {
             let expr = RangeExpr {
                 from_expr_opt: Some(Box::new(from_assignee_expr)),
                 range_op: {

--- a/src/parser/expr/struct_expr.rs
+++ b/src/parser/expr/struct_expr.rs
@@ -9,7 +9,7 @@ use crate::{
 
 impl ParseConstructExpr for StructExpr {
     fn parse(parser: &mut Parser) -> Result<StructExpr, ErrorsEmitted> {
-        let root = match &parser.current_token() {
+        let root = match parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
                 Ok(PathRoot::Identifier(Identifier::from(name)))
             }
@@ -27,7 +27,7 @@ impl ParseConstructExpr for StructExpr {
 
         parser.next_token();
 
-        let open_brace = match &parser.current_token() {
+        let open_brace = match parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -46,7 +46,7 @@ impl ParseConstructExpr for StructExpr {
         let struct_fields_opt =
             collection::get_collection(parser, parse_struct_field, &open_brace)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
                 Ok(StructExpr {
@@ -65,10 +65,10 @@ impl ParseConstructExpr for StructExpr {
 fn parse_struct_field(parser: &mut Parser) -> Result<StructField, ErrorsEmitted> {
     let attributes_opt = collection::get_attributes(parser, OuterAttr::outer_attr);
 
-    let field_name = match &parser.current_token().cloned() {
+    let field_name = match parser.current_token().cloned() {
         Some(Token::Identifier { name, .. }) => {
             parser.next_token();
-            Ok(Identifier::from(name))
+            Ok(Identifier(name))
         }
         Some(Token::EOF) | None => {
             parser.log_missing_token("identifier");
@@ -80,11 +80,11 @@ fn parse_struct_field(parser: &mut Parser) -> Result<StructField, ErrorsEmitted>
         }
     }?;
 
-    match &parser.current_token() {
+    match parser.current_token() {
         Some(Token::Colon { .. }) => {
             parser.next_token();
 
-            if let Some(Token::Comma { .. } | Token::RBrace { .. }) = &parser.current_token() {
+            if let Some(Token::Comma { .. } | Token::RBrace { .. }) = parser.current_token() {
                 parser.log_missing("expr", "value for struct field name");
                 return Err(ErrorsEmitted);
             }

--- a/src/parser/expr/struct_expr.rs
+++ b/src/parser/expr/struct_expr.rs
@@ -9,9 +9,9 @@ use crate::{
 
 impl ParseConstructExpr for StructExpr {
     fn parse(parser: &mut Parser) -> Result<StructExpr, ErrorsEmitted> {
-        let root = match parser.current_token() {
+        let root = match &parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
-                Ok(PathRoot::Identifier(Identifier::from(&name)))
+                Ok(PathRoot::Identifier(Identifier::from(name)))
             }
             Some(Token::SelfType { .. }) => Ok(PathRoot::SelfType(SelfType)),
             _ => {
@@ -27,7 +27,7 @@ impl ParseConstructExpr for StructExpr {
 
         parser.next_token();
 
-        let open_brace = match parser.current_token() {
+        let open_brace = match &parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -46,7 +46,7 @@ impl ParseConstructExpr for StructExpr {
         let struct_fields_opt =
             collection::get_collection(parser, parse_struct_field, &open_brace)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
                 Ok(StructExpr {
@@ -65,10 +65,10 @@ impl ParseConstructExpr for StructExpr {
 fn parse_struct_field(parser: &mut Parser) -> Result<StructField, ErrorsEmitted> {
     let attributes_opt = collection::get_attributes(parser, OuterAttr::outer_attr);
 
-    let field_name = match parser.current_token() {
+    let field_name = match &parser.current_token().cloned() {
         Some(Token::Identifier { name, .. }) => {
             parser.next_token();
-            Ok(Identifier(name))
+            Ok(Identifier::from(name))
         }
         Some(Token::EOF) | None => {
             parser.log_missing_token("identifier");
@@ -80,11 +80,11 @@ fn parse_struct_field(parser: &mut Parser) -> Result<StructField, ErrorsEmitted>
         }
     }?;
 
-    match parser.current_token() {
+    match &parser.current_token() {
         Some(Token::Colon { .. }) => {
             parser.next_token();
 
-            if let Some(Token::Comma { .. } | Token::RBrace { .. }) = parser.current_token() {
+            if let Some(Token::Comma { .. } | Token::RBrace { .. }) = &parser.current_token() {
                 parser.log_missing("expr", "value for struct field name");
                 return Err(ErrorsEmitted);
             }

--- a/src/parser/expr/tuple_expr.rs
+++ b/src/parser/expr/tuple_expr.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl ParseConstructExpr for TupleExpr {
     fn parse(parser: &mut Parser) -> Result<TupleExpr, ErrorsEmitted> {
-        let open_paren = match &parser.current_token() {
+        let open_paren = match parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -21,7 +21,7 @@ impl ParseConstructExpr for TupleExpr {
 
         let tuple_elements = parse_tuple_elements(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
                 Ok(TupleExpr { tuple_elements })
@@ -39,17 +39,17 @@ fn parse_tuple_elements(parser: &mut Parser) -> Result<TupleElements, ErrorsEmit
     let mut final_element_opt = None::<Box<Expression>>;
 
     while !matches!(
-        &parser.current_token(),
+        parser.current_token(),
         Some(Token::RParen { .. } | Token::EOF)
     ) {
         let element = parser.parse_expression(Precedence::Lowest)?;
 
-        if let Some(Token::Comma { .. }) = &parser.current_token() {
+        if let Some(Token::Comma { .. }) = parser.current_token() {
             elements.push(element);
             parser.next_token();
-        } else if !matches!(&parser.current_token(), Some(Token::RParen { .. })) {
+        } else if !matches!(parser.current_token(), Some(Token::RParen { .. })) {
             parser.log_unexpected_token("`,` or `)`");
-        } else if matches!(&parser.current_token(), Some(Token::RParen { .. })) {
+        } else if matches!(parser.current_token(), Some(Token::RParen { .. })) {
             final_element_opt = Some(Box::new(element));
             break;
         }
@@ -68,10 +68,10 @@ impl ParseOperatorExpr for TupleIndexExpr {
             ErrorsEmitted
         })?;
 
-        let index = match &parser.current_token().cloned() {
+        let index = match parser.current_token().cloned() {
             Some(Token::UIntLiteral { value, .. }) => {
                 parser.next_token();
-                Ok(*value)
+                Ok(value)
             }
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();

--- a/src/parser/expr/tuple_expr.rs
+++ b/src/parser/expr/tuple_expr.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl ParseConstructExpr for TupleExpr {
     fn parse(parser: &mut Parser) -> Result<TupleExpr, ErrorsEmitted> {
-        let open_paren = match parser.current_token() {
+        let open_paren = match &parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = parser.current_position();
                 parser.next_token();
@@ -21,7 +21,7 @@ impl ParseConstructExpr for TupleExpr {
 
         let tuple_elements = parse_tuple_elements(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
                 Ok(TupleExpr { tuple_elements })
@@ -39,17 +39,17 @@ fn parse_tuple_elements(parser: &mut Parser) -> Result<TupleElements, ErrorsEmit
     let mut final_element_opt = None::<Box<Expression>>;
 
     while !matches!(
-        parser.current_token(),
+        &parser.current_token(),
         Some(Token::RParen { .. } | Token::EOF)
     ) {
         let element = parser.parse_expression(Precedence::Lowest)?;
 
-        if let Some(Token::Comma { .. }) = parser.current_token() {
+        if let Some(Token::Comma { .. }) = &parser.current_token() {
             elements.push(element);
             parser.next_token();
-        } else if !matches!(parser.current_token(), Some(Token::RParen { .. })) {
+        } else if !matches!(&parser.current_token(), Some(Token::RParen { .. })) {
             parser.log_unexpected_token("`,` or `)`");
-        } else if matches!(parser.current_token(), Some(Token::RParen { .. })) {
+        } else if matches!(&parser.current_token(), Some(Token::RParen { .. })) {
             final_element_opt = Some(Box::new(element));
             break;
         }
@@ -68,10 +68,10 @@ impl ParseOperatorExpr for TupleIndexExpr {
             ErrorsEmitted
         })?;
 
-        let index = match parser.current_token() {
+        let index = match &parser.current_token().cloned() {
             Some(Token::UIntLiteral { value, .. }) => {
                 parser.next_token();
-                Ok(value)
+                Ok(*value)
             }
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();

--- a/src/parser/item.rs
+++ b/src/parser/item.rs
@@ -36,7 +36,7 @@ impl Item {
         parser.log_current_token(false);
         ////////////////////////////////////////////////////////////////////////////////
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Import { .. }) => Ok(Item::ImportDecl(ImportDecl::parse(
                 parser,
                 attributes_opt,
@@ -78,7 +78,7 @@ impl Item {
                 visibility,
             )?)),
             Some(Token::Impl { .. }) => {
-                if let Some(Token::For { .. }) = parser.peek_ahead_by(2) {
+                if let Some(Token::For { .. }) = &parser.peek_ahead_by(2) {
                     Ok(Item::TraitImplDef(TraitImplDef::parse(
                         parser,
                         attributes_opt,
@@ -120,9 +120,7 @@ impl ParseStatement for Item {
 
         let visibility = Visibility::visibility(parser)?;
 
-        let token = parser.current_token();
-
-        match token {
+        match &parser.current_token() {
             Some(Token::Import { .. }) => Ok(Statement::Item(Item::ImportDecl(ImportDecl::parse(
                 parser,
                 attributes_opt,
@@ -154,7 +152,7 @@ impl ParseStatement for Item {
                 attributes_opt,
                 visibility,
             )?))),
-            Some(Token::Struct { .. }) => match parser.peek_ahead_by(2) {
+            Some(Token::Struct { .. }) => match &parser.peek_ahead_by(2) {
                 Some(Token::LBrace { .. }) => Ok(Statement::Item(Item::StructDef(
                     StructDef::parse(parser, attributes_opt, visibility)?,
                 ))),
@@ -172,7 +170,7 @@ impl ParseStatement for Item {
             Some(Token::Func { .. }) => Ok(Statement::Item(Item::FunctionItem(
                 FunctionItem::parse(parser, attributes_opt, visibility)?,
             ))),
-            Some(Token::Impl { .. }) => match parser.peek_ahead_by(2) {
+            Some(Token::Impl { .. }) => match &parser.peek_ahead_by(2) {
                 Some(Token::For { .. }) => Ok(Statement::Item(Item::TraitImplDef(
                     TraitImplDef::parse(parser, attributes_opt, visibility)?,
                 ))),

--- a/src/parser/item.rs
+++ b/src/parser/item.rs
@@ -36,7 +36,7 @@ impl Item {
         parser.log_current_token(false);
         ////////////////////////////////////////////////////////////////////////////////
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Import { .. }) => Ok(Item::ImportDecl(ImportDecl::parse(
                 parser,
                 attributes_opt,
@@ -78,7 +78,7 @@ impl Item {
                 visibility,
             )?)),
             Some(Token::Impl { .. }) => {
-                if let Some(Token::For { .. }) = &parser.peek_ahead_by(2) {
+                if let Some(Token::For { .. }) = parser.peek_ahead_by(2) {
                     Ok(Item::TraitImplDef(TraitImplDef::parse(
                         parser,
                         attributes_opt,
@@ -120,7 +120,7 @@ impl ParseStatement for Item {
 
         let visibility = Visibility::visibility(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Import { .. }) => Ok(Statement::Item(Item::ImportDecl(ImportDecl::parse(
                 parser,
                 attributes_opt,
@@ -152,7 +152,7 @@ impl ParseStatement for Item {
                 attributes_opt,
                 visibility,
             )?))),
-            Some(Token::Struct { .. }) => match &parser.peek_ahead_by(2) {
+            Some(Token::Struct { .. }) => match parser.peek_ahead_by(2) {
                 Some(Token::LBrace { .. }) => Ok(Statement::Item(Item::StructDef(
                     StructDef::parse(parser, attributes_opt, visibility)?,
                 ))),
@@ -170,7 +170,7 @@ impl ParseStatement for Item {
             Some(Token::Func { .. }) => Ok(Statement::Item(Item::FunctionItem(
                 FunctionItem::parse(parser, attributes_opt, visibility)?,
             ))),
-            Some(Token::Impl { .. }) => match &parser.peek_ahead_by(2) {
+            Some(Token::Impl { .. }) => match parser.peek_ahead_by(2) {
                 Some(Token::For { .. }) => Ok(Statement::Item(Item::TraitImplDef(
                     TraitImplDef::parse(parser, attributes_opt, visibility)?,
                 ))),

--- a/src/parser/item/function_item.rs
+++ b/src/parser/item/function_item.rs
@@ -17,7 +17,7 @@ impl ParseDefItem for FunctionItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<FunctionItem, ErrorsEmitted> {
-        let kw_func = if let Some(Token::Func { .. }) = &parser.current_token() {
+        let kw_func = if let Some(Token::Func { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Func)
         } else {
@@ -37,7 +37,7 @@ impl ParseDefItem for FunctionItem {
             }
         }?;
 
-        let open_paren = match &parser.current_token() {
+        let open_paren = match parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -56,7 +56,7 @@ impl ParseDefItem for FunctionItem {
         let params_opt =
             collection::get_collection(parser, FunctionOrMethodParam::parse, &open_paren)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
             }
@@ -71,7 +71,7 @@ impl ParseDefItem for FunctionItem {
             }
         }
 
-        let return_type_opt = if let Some(Token::ThinArrow { .. }) = &parser.current_token() {
+        let return_type_opt = if let Some(Token::ThinArrow { .. }) = parser.current_token() {
             parser.next_token();
 
             if parser.current_token().is_some() {
@@ -84,7 +84,7 @@ impl ParseDefItem for FunctionItem {
             Ok(None)
         }?;
 
-        let block_opt = if let Some(Token::LBrace { .. }) = &parser.current_token() {
+        let block_opt = if let Some(Token::LBrace { .. }) = parser.current_token() {
             match parser.peek_ahead_by(1) {
                 Some(Token::RBrace { .. }) => {
                     parser.next_token();
@@ -117,11 +117,11 @@ impl ParseDefItem for FunctionItem {
 impl FunctionOrMethodParam {
     pub(crate) fn parse(parser: &mut Parser) -> Result<FunctionOrMethodParam, ErrorsEmitted> {
         let reference_op_opt = if let Some(Token::Ampersand { .. } | Token::AmpersandMut { .. }) =
-            &parser.current_token()
+            parser.current_token()
         {
             parser.next_token();
 
-            match &parser.current_token() {
+            match parser.current_token() {
                 Some(Token::Ampersand { .. }) => Some(ReferenceOp::Borrow),
                 Some(Token::AmpersandMut { .. }) => Some(ReferenceOp::MutableBorrow),
                 _ => None,
@@ -130,7 +130,7 @@ impl FunctionOrMethodParam {
             None
         };
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::SelfKeyword { .. }) => {
                 parser.next_token();
 
@@ -144,7 +144,7 @@ impl FunctionOrMethodParam {
             Some(Token::Identifier { .. } | Token::Ref { .. } | Token::Mut { .. }) => {
                 let param_name = IdentifierPatt::parse_patt(parser)?;
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::Colon { .. }) => {
                         parser.next_token();
                     }

--- a/src/parser/item/impl_def.rs
+++ b/src/parser/item/impl_def.rs
@@ -17,7 +17,7 @@ impl ParseDefItem for InherentImplDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         _visibility: Visibility,
     ) -> Result<InherentImplDef, ErrorsEmitted> {
-        let kw_impl = if let Some(Token::Impl { .. }) = parser.current_token() {
+        let kw_impl = if let Some(Token::Impl { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Impl)
         } else {
@@ -25,9 +25,9 @@ impl ParseDefItem for InherentImplDef {
             Err(ErrorsEmitted)
         }?;
 
-        let nominal_type = PathType::parse(parser, parser.current_token())?;
+        let nominal_type = PathType::parse(parser, parser.current_token().cloned())?;
 
-        let open_brace = match parser.current_token() {
+        let open_brace = match &parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -45,7 +45,7 @@ impl ParseDefItem for InherentImplDef {
 
         let associated_items_opt = collection::get_associated_items::<InherentImplItem>(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -75,7 +75,7 @@ impl ParseDefItem for TraitImplDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         _visibility: Visibility,
     ) -> Result<TraitImplDef, ErrorsEmitted> {
-        let kw_impl = if let Some(Token::Impl { .. }) = parser.current_token() {
+        let kw_impl = if let Some(Token::Impl { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Impl)
         } else {
@@ -83,9 +83,9 @@ impl ParseDefItem for TraitImplDef {
             Err(ErrorsEmitted)
         }?;
 
-        let token = parser.current_token();
+        let token = parser.current_token().cloned();
 
-        let implemented_trait_path = match token {
+        let implemented_trait_path = match &token {
             Some(Token::Identifier { .. }) => {
                 let path = PathType::parse(parser, token);
                 path
@@ -103,7 +103,7 @@ impl ParseDefItem for TraitImplDef {
             }
         }?;
 
-        let kw_for = if let Some(Token::For { .. }) = parser.current_token() {
+        let kw_for = if let Some(Token::For { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::For)
         } else {
@@ -113,7 +113,7 @@ impl ParseDefItem for TraitImplDef {
 
         let implementing_type = Type::parse(parser)?;
 
-        let open_brace = match parser.current_token() {
+        let open_brace = match &parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -131,7 +131,7 @@ impl ParseDefItem for TraitImplDef {
 
         let associated_items_opt = collection::get_associated_items::<TraitImplItem>(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -163,7 +163,7 @@ impl ParseAssociatedItem for InherentImplItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<InherentImplItem, ErrorsEmitted> {
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 if constant_decl.value_opt.is_none() {
@@ -200,7 +200,7 @@ impl ParseAssociatedItem for TraitImplItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitImplItem, ErrorsEmitted> {
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 if constant_decl.value_opt.is_none() {

--- a/src/parser/item/impl_def.rs
+++ b/src/parser/item/impl_def.rs
@@ -17,7 +17,7 @@ impl ParseDefItem for InherentImplDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         _visibility: Visibility,
     ) -> Result<InherentImplDef, ErrorsEmitted> {
-        let kw_impl = if let Some(Token::Impl { .. }) = &parser.current_token() {
+        let kw_impl = if let Some(Token::Impl { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Impl)
         } else {
@@ -27,7 +27,7 @@ impl ParseDefItem for InherentImplDef {
 
         let nominal_type = PathType::parse(parser, parser.current_token().cloned())?;
 
-        let open_brace = match &parser.current_token() {
+        let open_brace = match parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -45,7 +45,7 @@ impl ParseDefItem for InherentImplDef {
 
         let associated_items_opt = collection::get_associated_items::<InherentImplItem>(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -75,7 +75,7 @@ impl ParseDefItem for TraitImplDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         _visibility: Visibility,
     ) -> Result<TraitImplDef, ErrorsEmitted> {
-        let kw_impl = if let Some(Token::Impl { .. }) = &parser.current_token() {
+        let kw_impl = if let Some(Token::Impl { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Impl)
         } else {
@@ -103,7 +103,7 @@ impl ParseDefItem for TraitImplDef {
             }
         }?;
 
-        let kw_for = if let Some(Token::For { .. }) = &parser.current_token() {
+        let kw_for = if let Some(Token::For { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::For)
         } else {
@@ -113,7 +113,7 @@ impl ParseDefItem for TraitImplDef {
 
         let implementing_type = Type::parse(parser)?;
 
-        let open_brace = match &parser.current_token() {
+        let open_brace = match parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -131,7 +131,7 @@ impl ParseDefItem for TraitImplDef {
 
         let associated_items_opt = collection::get_associated_items::<TraitImplItem>(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -163,7 +163,7 @@ impl ParseAssociatedItem for InherentImplItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<InherentImplItem, ErrorsEmitted> {
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 if constant_decl.value_opt.is_none() {
@@ -200,7 +200,7 @@ impl ParseAssociatedItem for TraitImplItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitImplItem, ErrorsEmitted> {
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 if constant_decl.value_opt.is_none() {

--- a/src/parser/item/import_decl.rs
+++ b/src/parser/item/import_decl.rs
@@ -16,7 +16,7 @@ impl ParseDeclItem for ImportDecl {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<ImportDecl, ErrorsEmitted> {
-        let kw_import = if let Some(Token::Import { .. }) = parser.current_token() {
+        let kw_import = if let Some(Token::Import { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Import)
         } else {
@@ -26,7 +26,7 @@ impl ParseDeclItem for ImportDecl {
 
         let import_tree = parse_import_tree(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Semicolon { .. }) => {
                 parser.next_token();
                 Ok(ImportDecl {
@@ -54,25 +54,25 @@ fn parse_import_tree(parser: &mut Parser) -> Result<ImportTree, ErrorsEmitted> {
     let first_segment = parse_path_segment(parser)?;
     path_segments.push(first_segment);
 
-    while let Some(Token::DblColon { .. }) = parser.current_token() {
+    while let Some(Token::DblColon { .. }) = &parser.current_token() {
         parser.next_token();
         let next_segment = parse_path_segment(parser)?;
         path_segments.push(next_segment);
     }
 
-    let wildcard_opt = if let Some(Token::ColonColonAsterisk { .. }) = parser.current_token() {
+    let wildcard_opt = if let Some(Token::ColonColonAsterisk { .. }) = &parser.current_token() {
         parser.next_token();
         Some(Separator::ColonColonAsterisk)
     } else {
         None
     };
 
-    let as_clause_opt = if let Some(Token::As { .. }) = parser.current_token() {
+    let as_clause_opt = if let Some(Token::As { .. }) = &parser.current_token() {
         let kw_as = Keyword::As;
         parser.next_token();
 
-        let id = if let Some(Token::Identifier { name, .. }) = parser.next_token() {
-            Ok(Identifier(name))
+        let id = if let Some(Token::Identifier { name, .. }) = &parser.next_token() {
+            Ok(Identifier::from(name))
         } else {
             parser.log_unexpected_token("identifier");
             Err(ErrorsEmitted)
@@ -91,9 +91,9 @@ fn parse_import_tree(parser: &mut Parser) -> Result<ImportTree, ErrorsEmitted> {
 }
 
 fn parse_path_segment(parser: &mut Parser) -> Result<PathSegment, ErrorsEmitted> {
-    let root = PathType::parse(parser, parser.current_token())?;
+    let root = PathType::parse(parser, parser.current_token().cloned())?;
 
-    let subset_opt = if let Some(Token::LBrace { .. }) = parser.peek_ahead_by(1) {
+    let subset_opt = if let Some(Token::LBrace { .. }) = &parser.peek_ahead_by(1) {
         parser.next_token();
         Some(parse_path_subset(parser)?)
     } else {
@@ -104,7 +104,7 @@ fn parse_path_segment(parser: &mut Parser) -> Result<PathSegment, ErrorsEmitted>
 }
 
 fn parse_path_subset(parser: &mut Parser) -> Result<PathSubset, ErrorsEmitted> {
-    let open_brace = if let Some(Token::LBrace { .. }) = parser.current_token() {
+    let open_brace = if let Some(Token::LBrace { .. }) = &parser.current_token() {
         let position = Position::new(parser.current, &parser.stream.span().input());
         parser.next_token();
         Ok(Delimiter::LBrace { position })
@@ -121,7 +121,7 @@ fn parse_path_subset(parser: &mut Parser) -> Result<PathSubset, ErrorsEmitted> {
             Err(ErrorsEmitted)
         }?;
 
-    match parser.current_token() {
+    match &parser.current_token() {
         Some(Token::RBrace { .. }) => {
             parser.next_token();
 

--- a/src/parser/item/import_decl.rs
+++ b/src/parser/item/import_decl.rs
@@ -16,7 +16,7 @@ impl ParseDeclItem for ImportDecl {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<ImportDecl, ErrorsEmitted> {
-        let kw_import = if let Some(Token::Import { .. }) = &parser.current_token() {
+        let kw_import = if let Some(Token::Import { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Import)
         } else {
@@ -26,7 +26,7 @@ impl ParseDeclItem for ImportDecl {
 
         let import_tree = parse_import_tree(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Semicolon { .. }) => {
                 parser.next_token();
                 Ok(ImportDecl {
@@ -54,25 +54,25 @@ fn parse_import_tree(parser: &mut Parser) -> Result<ImportTree, ErrorsEmitted> {
     let first_segment = parse_path_segment(parser)?;
     path_segments.push(first_segment);
 
-    while let Some(Token::DblColon { .. }) = &parser.current_token() {
+    while let Some(Token::DblColon { .. }) = parser.current_token() {
         parser.next_token();
         let next_segment = parse_path_segment(parser)?;
         path_segments.push(next_segment);
     }
 
-    let wildcard_opt = if let Some(Token::ColonColonAsterisk { .. }) = &parser.current_token() {
+    let wildcard_opt = if let Some(Token::ColonColonAsterisk { .. }) = parser.current_token() {
         parser.next_token();
         Some(Separator::ColonColonAsterisk)
     } else {
         None
     };
 
-    let as_clause_opt = if let Some(Token::As { .. }) = &parser.current_token() {
+    let as_clause_opt = if let Some(Token::As { .. }) = parser.current_token() {
         let kw_as = Keyword::As;
         parser.next_token();
 
-        let id = if let Some(Token::Identifier { name, .. }) = &parser.next_token() {
-            Ok(Identifier::from(name))
+        let id = if let Some(Token::Identifier { name, .. }) = parser.next_token() {
+            Ok(Identifier(name))
         } else {
             parser.log_unexpected_token("identifier");
             Err(ErrorsEmitted)
@@ -104,7 +104,7 @@ fn parse_path_segment(parser: &mut Parser) -> Result<PathSegment, ErrorsEmitted>
 }
 
 fn parse_path_subset(parser: &mut Parser) -> Result<PathSubset, ErrorsEmitted> {
-    let open_brace = if let Some(Token::LBrace { .. }) = &parser.current_token() {
+    let open_brace = if let Some(Token::LBrace { .. }) = parser.current_token() {
         let position = Position::new(parser.current, &parser.stream.span().input());
         parser.next_token();
         Ok(Delimiter::LBrace { position })
@@ -121,7 +121,7 @@ fn parse_path_subset(parser: &mut Parser) -> Result<PathSubset, ErrorsEmitted> {
             Err(ErrorsEmitted)
         }?;
 
-    match &parser.current_token() {
+    match parser.current_token() {
         Some(Token::RBrace { .. }) => {
             parser.next_token();
 

--- a/src/parser/item/struct_def.rs
+++ b/src/parser/item/struct_def.rs
@@ -16,7 +16,7 @@ impl ParseDefItem for StructDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<StructDef, ErrorsEmitted> {
-        let kw_struct = if let Some(Token::Struct { .. }) = &parser.current_token() {
+        let kw_struct = if let Some(Token::Struct { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Struct)
         } else {
@@ -24,8 +24,8 @@ impl ParseDefItem for StructDef {
             Err(ErrorsEmitted)
         }?;
 
-        let struct_name = match &parser.next_token() {
-            Some(Token::Identifier { name, .. }) => Ok(Identifier::from(name)),
+        let struct_name = match parser.next_token() {
+            Some(Token::Identifier { name, .. }) => Ok(Identifier(name)),
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();
                 Err(ErrorsEmitted)
@@ -37,7 +37,7 @@ impl ParseDefItem for StructDef {
             }
         }?;
 
-        let open_brace = match &parser.current_token() {
+        let open_brace = match parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -55,7 +55,7 @@ impl ParseDefItem for StructDef {
 
         let fields_opt = collection::get_collection(parser, StructDefField::parse, &open_brace)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -86,7 +86,7 @@ impl ParseDefItem for TupleStructDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TupleStructDef, ErrorsEmitted> {
-        let kw_struct = if let Some(Token::Struct { .. }) = &parser.current_token() {
+        let kw_struct = if let Some(Token::Struct { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Struct)
         } else {
@@ -94,14 +94,14 @@ impl ParseDefItem for TupleStructDef {
             Err(ErrorsEmitted)
         }?;
 
-        let struct_name = if let Some(Token::Identifier { name, .. }) = &parser.next_token() {
-            Ok(Identifier::from(name))
+        let struct_name = if let Some(Token::Identifier { name, .. }) = parser.next_token() {
+            Ok(Identifier(name))
         } else {
             parser.log_unexpected_token("struct name");
             Err(ErrorsEmitted)
         }?;
 
-        let open_paren = match &parser.current_token() {
+        let open_paren = match parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -120,7 +120,7 @@ impl ParseDefItem for TupleStructDef {
         let tuple_struct_fields_opt =
             collection::get_collection(parser, parse_tuple_struct_def_field, &open_paren)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
             }
@@ -135,7 +135,7 @@ impl ParseDefItem for TupleStructDef {
             }
         }
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Semicolon { .. }) => {
                 parser.next_token();
                 Ok(TupleStructDef {
@@ -164,15 +164,15 @@ impl StructDefField {
 
         let visibility = Visibility::visibility(parser)?;
 
-        let field_name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
+        let field_name = if let Some(Token::Identifier { name, .. }) = parser.current_token().cloned() {
             parser.next_token();
-            Ok(Identifier::from(name))
+            Ok(Identifier(name))
         } else {
             parser.log_missing_token("struct field identifier");
             Err(ErrorsEmitted)
         }?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Colon { .. }) => {
                 parser.next_token();
             }

--- a/src/parser/item/struct_def.rs
+++ b/src/parser/item/struct_def.rs
@@ -16,7 +16,7 @@ impl ParseDefItem for StructDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<StructDef, ErrorsEmitted> {
-        let kw_struct = if let Some(Token::Struct { .. }) = parser.current_token() {
+        let kw_struct = if let Some(Token::Struct { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Struct)
         } else {
@@ -24,8 +24,8 @@ impl ParseDefItem for StructDef {
             Err(ErrorsEmitted)
         }?;
 
-        let struct_name = match parser.next_token() {
-            Some(Token::Identifier { name, .. }) => Ok(Identifier(name)),
+        let struct_name = match &parser.next_token() {
+            Some(Token::Identifier { name, .. }) => Ok(Identifier::from(name)),
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();
                 Err(ErrorsEmitted)
@@ -37,7 +37,7 @@ impl ParseDefItem for StructDef {
             }
         }?;
 
-        let open_brace = match parser.current_token() {
+        let open_brace = match &parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -55,7 +55,7 @@ impl ParseDefItem for StructDef {
 
         let fields_opt = collection::get_collection(parser, StructDefField::parse, &open_brace)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -86,7 +86,7 @@ impl ParseDefItem for TupleStructDef {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TupleStructDef, ErrorsEmitted> {
-        let kw_struct = if let Some(Token::Struct { .. }) = parser.current_token() {
+        let kw_struct = if let Some(Token::Struct { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Struct)
         } else {
@@ -94,14 +94,14 @@ impl ParseDefItem for TupleStructDef {
             Err(ErrorsEmitted)
         }?;
 
-        let struct_name = if let Some(Token::Identifier { name, .. }) = parser.next_token() {
-            Ok(Identifier(name))
+        let struct_name = if let Some(Token::Identifier { name, .. }) = &parser.next_token() {
+            Ok(Identifier::from(name))
         } else {
             parser.log_unexpected_token("struct name");
             Err(ErrorsEmitted)
         }?;
 
-        let open_paren = match parser.current_token() {
+        let open_paren = match &parser.current_token() {
             Some(Token::LParen { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -120,7 +120,7 @@ impl ParseDefItem for TupleStructDef {
         let tuple_struct_fields_opt =
             collection::get_collection(parser, parse_tuple_struct_def_field, &open_paren)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
             }
@@ -135,7 +135,7 @@ impl ParseDefItem for TupleStructDef {
             }
         }
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Semicolon { .. }) => {
                 parser.next_token();
                 Ok(TupleStructDef {
@@ -164,15 +164,15 @@ impl StructDefField {
 
         let visibility = Visibility::visibility(parser)?;
 
-        let field_name = if let Some(Token::Identifier { name, .. }) = parser.current_token() {
+        let field_name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
             parser.next_token();
-            Ok(Identifier(name))
+            Ok(Identifier::from(name))
         } else {
             parser.log_missing_token("struct field identifier");
             Err(ErrorsEmitted)
         }?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Colon { .. }) => {
                 parser.next_token();
             }

--- a/src/parser/item/trait_def.rs
+++ b/src/parser/item/trait_def.rs
@@ -17,7 +17,7 @@ impl ParseDefItem for TraitDef {
         outer_attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitDef, ErrorsEmitted> {
-        let kw_trait = if let Some(Token::Trait { .. }) = &parser.current_token() {
+        let kw_trait = if let Some(Token::Trait { .. }) = parser.current_token() {
             parser.next_token();
             Ok(Keyword::Trait)
         } else {
@@ -25,8 +25,8 @@ impl ParseDefItem for TraitDef {
             Err(ErrorsEmitted)
         }?;
 
-        let trait_name = match &parser.next_token() {
-            Some(Token::Identifier { name, .. }) => Ok(Identifier::from(name)),
+        let trait_name = match parser.next_token() {
+            Some(Token::Identifier { name, .. }) => Ok(Identifier(name)),
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();
                 Err(ErrorsEmitted)
@@ -37,7 +37,7 @@ impl ParseDefItem for TraitDef {
             }
         }?;
 
-        let open_brace = match &parser.current_token() {
+        let open_brace = match parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -57,7 +57,7 @@ impl ParseDefItem for TraitDef {
 
         let trait_items_opt = collection::get_associated_items::<TraitDefItem>(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -89,7 +89,7 @@ impl ParseAssociatedItem for TraitDefItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitDefItem, ErrorsEmitted> {
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 Ok(TraitDefItem::ConstantDecl(constant_decl))

--- a/src/parser/item/trait_def.rs
+++ b/src/parser/item/trait_def.rs
@@ -17,7 +17,7 @@ impl ParseDefItem for TraitDef {
         outer_attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitDef, ErrorsEmitted> {
-        let kw_trait = if let Some(Token::Trait { .. }) = parser.current_token() {
+        let kw_trait = if let Some(Token::Trait { .. }) = &parser.current_token() {
             parser.next_token();
             Ok(Keyword::Trait)
         } else {
@@ -25,8 +25,8 @@ impl ParseDefItem for TraitDef {
             Err(ErrorsEmitted)
         }?;
 
-        let trait_name = match parser.next_token() {
-            Some(Token::Identifier { name, .. }) => Ok(Identifier(name)),
+        let trait_name = match &parser.next_token() {
+            Some(Token::Identifier { name, .. }) => Ok(Identifier::from(name)),
             Some(Token::EOF) | None => {
                 parser.log_unexpected_eoi();
                 Err(ErrorsEmitted)
@@ -37,7 +37,7 @@ impl ParseDefItem for TraitDef {
             }
         }?;
 
-        let open_brace = match parser.current_token() {
+        let open_brace = match &parser.current_token() {
             Some(Token::LBrace { .. }) => {
                 let position = Position::new(parser.current, &parser.stream.span().input());
                 parser.next_token();
@@ -57,7 +57,7 @@ impl ParseDefItem for TraitDef {
 
         let trait_items_opt = collection::get_associated_items::<TraitDefItem>(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
 
@@ -89,7 +89,7 @@ impl ParseAssociatedItem for TraitDefItem {
         attributes_opt: Option<Vec<OuterAttr>>,
         visibility: Visibility,
     ) -> Result<TraitDefItem, ErrorsEmitted> {
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::Const { .. }) => {
                 let constant_decl = ConstantDecl::parse(parser, attributes_opt, visibility)?;
                 Ok(TraitDefItem::ConstantDecl(constant_decl))
@@ -102,7 +102,7 @@ impl ParseAssociatedItem for TraitDefItem {
                 let function_def = FunctionItem::parse(parser, attributes_opt, visibility)?;
                 if function_def.block_opt.is_some() {
                     parser.log_error(crate::error::ParserErrorKind::ExtraTokens {
-                        token: parser.current_token(),
+                        token: parser.current_token().cloned(),
                         msg: "Functions in trait definitions cannot have bodies".to_string(),
                     });
                     Err(ErrorsEmitted)

--- a/src/parser/path_type.rs
+++ b/src/parser/path_type.rs
@@ -48,7 +48,7 @@ impl PathType {
             | Token::For { .. }
             | Token::EOF,
         )
-        | None = &parser.current_token()
+        | None = parser.current_token()
         {
             return Ok(PathType {
                 path_root,
@@ -61,13 +61,13 @@ impl PathType {
             });
         }
 
-        while let Some(Token::DblColon { .. }) = &parser.current_token() {
-            match &parser.peek_ahead_by(1).cloned() {
+        while let Some(Token::DblColon { .. }) = parser.current_token() {
+            match parser.peek_ahead_by(1).cloned() {
                 Some(Token::Identifier { name, .. }) => {
                     parser.next_token();
                     parser.next_token();
 
-                    tree.push(Identifier::from(name));
+                    tree.push(Identifier(name));
                 }
                 Some(Token::LBrace { .. }) => break,
                 Some(Token::EOF) | None => {

--- a/src/parser/path_type.rs
+++ b/src/parser/path_type.rs
@@ -48,7 +48,7 @@ impl PathType {
             | Token::For { .. }
             | Token::EOF,
         )
-        | None = parser.current_token()
+        | None = &parser.current_token()
         {
             return Ok(PathType {
                 path_root,
@@ -61,13 +61,13 @@ impl PathType {
             });
         }
 
-        while let Some(Token::DblColon { .. }) = parser.current_token() {
-            match parser.peek_ahead_by(1) {
+        while let Some(Token::DblColon { .. }) = &parser.current_token() {
+            match &parser.peek_ahead_by(1).cloned() {
                 Some(Token::Identifier { name, .. }) => {
                     parser.next_token();
                     parser.next_token();
 
-                    tree.push(Identifier(name));
+                    tree.push(Identifier::from(name));
                 }
                 Some(Token::LBrace { .. }) => break,
                 Some(Token::EOF) | None => {

--- a/src/parser/patt/identifier_patt.rs
+++ b/src/parser/patt/identifier_patt.rs
@@ -16,23 +16,23 @@ impl ParsePattern for IdentifierPatt {
         parser.log_current_token(false);
         ////////////////////////////////////////////////////////////////////////////////
 
-        let kw_ref_opt = if let Some(Token::Ref { .. }) = parser.current_token() {
+        let kw_ref_opt = if let Some(Token::Ref { .. }) = &parser.current_token() {
             parser.next_token();
             Some(Keyword::Ref)
         } else {
             None
         };
 
-        let kw_mut_opt = if let Some(Token::Mut { .. }) = parser.current_token() {
+        let kw_mut_opt = if let Some(Token::Mut { .. }) = &parser.current_token() {
             parser.next_token();
             Some(Keyword::Mut)
         } else {
             None
         };
 
-        let name = if let Some(Token::Identifier { name, .. }) = parser.current_token() {
+        let name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
             parser.next_token();
-            Ok(Identifier(name))
+            Ok(Identifier::from(name))
         } else {
             parser.log_unexpected_token("identifier");
             Err(ErrorsEmitted)

--- a/src/parser/patt/identifier_patt.rs
+++ b/src/parser/patt/identifier_patt.rs
@@ -16,23 +16,23 @@ impl ParsePattern for IdentifierPatt {
         parser.log_current_token(false);
         ////////////////////////////////////////////////////////////////////////////////
 
-        let kw_ref_opt = if let Some(Token::Ref { .. }) = &parser.current_token() {
+        let kw_ref_opt = if let Some(Token::Ref { .. }) = parser.current_token() {
             parser.next_token();
             Some(Keyword::Ref)
         } else {
             None
         };
 
-        let kw_mut_opt = if let Some(Token::Mut { .. }) = &parser.current_token() {
+        let kw_mut_opt = if let Some(Token::Mut { .. }) = parser.current_token() {
             parser.next_token();
             Some(Keyword::Mut)
         } else {
             None
         };
 
-        let name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
+        let name = if let Some(Token::Identifier { name, .. }) = parser.current_token().cloned() {
             parser.next_token();
-            Ok(Identifier::from(name))
+            Ok(Identifier(name))
         } else {
             parser.log_unexpected_token("identifier");
             Err(ErrorsEmitted)

--- a/src/parser/patt/path_patt.rs
+++ b/src/parser/patt/path_patt.rs
@@ -18,7 +18,7 @@ impl ParsePattern for PathPatt {
 
         let mut tree: Vec<Identifier> = Vec::new();
 
-        let path_root = match &parser.current_token() {
+        let path_root = match parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
                 Ok(PathRoot::Identifier(Identifier::from(name)))
             }
@@ -36,12 +36,12 @@ impl ParsePattern for PathPatt {
 
         parser.next_token();
 
-        while let Some(Token::DblColon { .. }) = &parser.current_token() {
-            if let Some(Token::Identifier { name, .. }) = &parser.peek_ahead_by(1).cloned() {
+        while let Some(Token::DblColon { .. }) = parser.current_token() {
+            if let Some(Token::Identifier { name, .. }) = parser.peek_ahead_by(1).cloned() {
                 parser.next_token();
                 parser.next_token();
 
-                tree.push(Identifier::from(name));
+                tree.push(Identifier(name));
             } else {
                 break;
             }

--- a/src/parser/patt/path_patt.rs
+++ b/src/parser/patt/path_patt.rs
@@ -18,9 +18,9 @@ impl ParsePattern for PathPatt {
 
         let mut tree: Vec<Identifier> = Vec::new();
 
-        let path_root = match parser.current_token() {
+        let path_root = match &parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
-                Ok(PathRoot::Identifier(Identifier::from(&name)))
+                Ok(PathRoot::Identifier(Identifier::from(name)))
             }
             Some(Token::SelfKeyword { .. }) => Ok(PathRoot::SelfKeyword),
             Some(Token::SelfType { .. }) => Ok(PathRoot::SelfType(SelfType)),
@@ -36,12 +36,12 @@ impl ParsePattern for PathPatt {
 
         parser.next_token();
 
-        while let Some(Token::DblColon { .. }) = parser.current_token() {
-            if let Some(Token::Identifier { name, .. }) = parser.peek_ahead_by(1) {
+        while let Some(Token::DblColon { .. }) = &parser.current_token() {
+            if let Some(Token::Identifier { name, .. }) = &parser.peek_ahead_by(1).cloned() {
                 parser.next_token();
                 parser.next_token();
 
-                tree.push(Identifier(name));
+                tree.push(Identifier::from(name));
             } else {
                 break;
             }

--- a/src/parser/patt/struct_patt.rs
+++ b/src/parser/patt/struct_patt.rs
@@ -11,9 +11,9 @@ use crate::{
 
 impl ParsePattern for StructPatt {
     fn parse_patt(parser: &mut Parser) -> Result<StructPatt, ErrorsEmitted> {
-        let path_root = match parser.current_token() {
+        let path_root = match &parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
-                Ok(PathRoot::Identifier(Identifier::from(&name)))
+                Ok(PathRoot::Identifier(Identifier::from(name)))
             }
             Some(Token::SelfType { .. }) => Ok(PathRoot::SelfType(SelfType)),
             _ => {
@@ -29,7 +29,7 @@ impl ParsePattern for StructPatt {
 
         parser.next_token();
 
-        let open_brace = if let Some(Token::LBrace { .. }) = parser.current_token() {
+        let open_brace = if let Some(Token::LBrace { .. }) = &parser.current_token() {
             let position = Position::new(parser.current, &parser.stream.span().input());
             parser.next_token();
             Ok(Delimiter::LBrace { position })
@@ -40,7 +40,7 @@ impl ParsePattern for StructPatt {
 
         let fields_opt = collection::get_collection(parser, parse_struct_patt_field, &open_brace)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
                 Ok(StructPatt {
@@ -62,15 +62,15 @@ impl ParsePattern for StructPatt {
 }
 
 fn parse_struct_patt_field(parser: &mut Parser) -> Result<StructPattField, ErrorsEmitted> {
-    let field_name = if let Some(Token::Identifier { name, .. }) = parser.current_token() {
+    let field_name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
         parser.next_token();
-        Ok(Identifier(name))
+        Ok(Identifier::from(name))
     } else {
         parser.log_missing_token("struct field identifier");
         Err(ErrorsEmitted)
     }?;
 
-    match parser.current_token() {
+    match &parser.current_token() {
         Some(Token::Colon { .. }) => {
             parser.next_token();
         }
@@ -96,9 +96,9 @@ fn parse_struct_patt_field(parser: &mut Parser) -> Result<StructPattField, Error
 
 impl ParsePattern for TupleStructPatt {
     fn parse_patt(parser: &mut Parser) -> Result<TupleStructPatt, ErrorsEmitted> {
-        let path_root = match parser.current_token() {
+        let path_root = match &parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
-                Ok(PathRoot::Identifier(Identifier::from(&name)))
+                Ok(PathRoot::Identifier(Identifier::from(name)))
             }
             Some(Token::SelfType { .. }) => Ok(PathRoot::SelfType(SelfType)),
             _ => {
@@ -114,7 +114,7 @@ impl ParsePattern for TupleStructPatt {
 
         parser.next_token();
 
-        let open_paren = if let Some(Token::LParen { .. }) = parser.current_token() {
+        let open_paren = if let Some(Token::LParen { .. }) = &parser.current_token() {
             let position = Position::new(parser.current, &parser.stream.span().input());
             parser.next_token();
             Ok(Delimiter::LParen { position })
@@ -125,7 +125,7 @@ impl ParsePattern for TupleStructPatt {
 
         let elements_opt = parse_tuple_struct_patterns(parser)?;
 
-        match parser.current_token() {
+        match &parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
                 Ok(TupleStructPatt {
@@ -150,16 +150,16 @@ fn parse_tuple_struct_patterns(parser: &mut Parser) -> Result<Option<Vec<Pattern
     let mut patterns: Vec<Pattern> = Vec::new();
 
     while !matches!(
-        parser.current_token().as_ref(),
+        &parser.current_token(),
         Some(Token::RParen { .. } | Token::EOF),
     ) {
         let pattern = parser.parse_pattern()?;
         patterns.push(pattern);
 
-        if let Some(Token::Comma { .. }) = parser.current_token().as_ref() {
+        if let Some(Token::Comma { .. }) = &parser.current_token() {
             parser.next_token();
         } else if !matches!(
-            parser.current_token().as_ref(),
+            &parser.current_token(),
             Some(Token::RParen { .. } | Token::EOF)
         ) {
             parser.log_unexpected_token("`,` or `)`");

--- a/src/parser/patt/struct_patt.rs
+++ b/src/parser/patt/struct_patt.rs
@@ -11,7 +11,7 @@ use crate::{
 
 impl ParsePattern for StructPatt {
     fn parse_patt(parser: &mut Parser) -> Result<StructPatt, ErrorsEmitted> {
-        let path_root = match &parser.current_token() {
+        let path_root = match parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
                 Ok(PathRoot::Identifier(Identifier::from(name)))
             }
@@ -29,7 +29,7 @@ impl ParsePattern for StructPatt {
 
         parser.next_token();
 
-        let open_brace = if let Some(Token::LBrace { .. }) = &parser.current_token() {
+        let open_brace = if let Some(Token::LBrace { .. }) = parser.current_token() {
             let position = Position::new(parser.current, &parser.stream.span().input());
             parser.next_token();
             Ok(Delimiter::LBrace { position })
@@ -40,7 +40,7 @@ impl ParsePattern for StructPatt {
 
         let fields_opt = collection::get_collection(parser, parse_struct_patt_field, &open_brace)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RBrace { .. }) => {
                 parser.next_token();
                 Ok(StructPatt {
@@ -62,15 +62,15 @@ impl ParsePattern for StructPatt {
 }
 
 fn parse_struct_patt_field(parser: &mut Parser) -> Result<StructPattField, ErrorsEmitted> {
-    let field_name = if let Some(Token::Identifier { name, .. }) = &parser.current_token().cloned() {
+    let field_name = if let Some(Token::Identifier { name, .. }) = parser.current_token().cloned() {
         parser.next_token();
-        Ok(Identifier::from(name))
+        Ok(Identifier(name))
     } else {
         parser.log_missing_token("struct field identifier");
         Err(ErrorsEmitted)
     }?;
 
-    match &parser.current_token() {
+    match parser.current_token() {
         Some(Token::Colon { .. }) => {
             parser.next_token();
         }
@@ -96,7 +96,7 @@ fn parse_struct_patt_field(parser: &mut Parser) -> Result<StructPattField, Error
 
 impl ParsePattern for TupleStructPatt {
     fn parse_patt(parser: &mut Parser) -> Result<TupleStructPatt, ErrorsEmitted> {
-        let path_root = match &parser.current_token() {
+        let path_root = match parser.current_token() {
             Some(Token::Identifier { name, .. }) => {
                 Ok(PathRoot::Identifier(Identifier::from(name)))
             }
@@ -114,7 +114,7 @@ impl ParsePattern for TupleStructPatt {
 
         parser.next_token();
 
-        let open_paren = if let Some(Token::LParen { .. }) = &parser.current_token() {
+        let open_paren = if let Some(Token::LParen { .. }) = parser.current_token() {
             let position = Position::new(parser.current, &parser.stream.span().input());
             parser.next_token();
             Ok(Delimiter::LParen { position })
@@ -125,7 +125,7 @@ impl ParsePattern for TupleStructPatt {
 
         let elements_opt = parse_tuple_struct_patterns(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
                 Ok(TupleStructPatt {
@@ -150,16 +150,16 @@ fn parse_tuple_struct_patterns(parser: &mut Parser) -> Result<Option<Vec<Pattern
     let mut patterns: Vec<Pattern> = Vec::new();
 
     while !matches!(
-        &parser.current_token(),
+        parser.current_token(),
         Some(Token::RParen { .. } | Token::EOF),
     ) {
         let pattern = parser.parse_pattern()?;
         patterns.push(pattern);
 
-        if let Some(Token::Comma { .. }) = &parser.current_token() {
+        if let Some(Token::Comma { .. }) = parser.current_token() {
             parser.next_token();
         } else if !matches!(
-            &parser.current_token(),
+            parser.current_token(),
             Some(Token::RParen { .. } | Token::EOF)
         ) {
             parser.log_unexpected_token("`,` or `)`");

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -65,7 +65,7 @@ impl Type {
                 })
             }
             Some(Token::VecType { .. }) => {
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::LessThan { .. }) => {
                         parser.next_token();
                     }
@@ -81,7 +81,7 @@ impl Type {
 
                 let ty = Type::parse(parser)?;
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::GreaterThan { .. }) => {
                         parser.next_token();
                         Ok(Type::Vec {
@@ -100,7 +100,7 @@ impl Type {
             }
 
             Some(Token::MappingType { .. }) => {
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::LessThan { .. }) => {
                         parser.next_token();
                     }
@@ -116,7 +116,7 @@ impl Type {
 
                 let key_type = Box::new(Type::parse(parser)?);
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::Comma { .. }) => {
                         parser.next_token();
                     }
@@ -132,7 +132,7 @@ impl Type {
 
                 let value_type = Box::new(Type::parse(parser)?);
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::GreaterThan { .. }) => {
                         parser.next_token();
 
@@ -153,7 +153,7 @@ impl Type {
             }
 
             Some(Token::OptionType { .. }) => {
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::LessThan { .. }) => {
                         parser.next_token();
                     }
@@ -169,7 +169,7 @@ impl Type {
 
                 let ty = Type::parse(parser)?;
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::GreaterThan { .. }) => {
                         parser.next_token();
 
@@ -190,7 +190,7 @@ impl Type {
             }
 
             Some(Token::ResultType { .. }) => {
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::LessThan { .. }) => {
                         parser.next_token();
                     }
@@ -205,7 +205,7 @@ impl Type {
                 }
                 let ok_type = Box::new(Type::parse(parser)?);
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::Comma { .. }) => {
                         parser.next_token();
                     }
@@ -220,7 +220,7 @@ impl Type {
                 }
                 let err_type = Box::new(Type::parse(parser)?);
 
-                match &parser.current_token() {
+                match parser.current_token() {
                     Some(Token::GreaterThan { .. }) => {
                         parser.next_token();
                         Ok(Type::Result { ok_type, err_type })
@@ -264,7 +264,7 @@ impl Type {
                 Ok(Type::UserDefined(path))
             }
 
-            Some(Token::SelfType { .. }) => match &parser.peek_ahead_by(1) {
+            Some(Token::SelfType { .. }) => match parser.peek_ahead_by(1) {
                 Some(Token::DblColon { .. }) => {
                     let path = PathType::parse(parser, token)?;
                     Ok(Type::UserDefined(path))
@@ -298,7 +298,7 @@ fn parse_function_ptr_type(
         Err(ErrorsEmitted)
     }?;
 
-    let open_paren = match &parser.current_token() {
+    let open_paren = match parser.current_token() {
         Some(Token::LParen { .. }) => {
             let position = Position::new(parser.current, &parser.stream.span().input());
             parser.next_token();
@@ -315,7 +315,7 @@ fn parse_function_ptr_type(
     }?;
 
     // `&self` and `&mut self` can only occur as the first parameter in a method
-    if let Some(Token::Ampersand { .. } | Token::AmpersandMut { .. }) = &parser.current_token() {
+    if let Some(Token::Ampersand { .. } | Token::AmpersandMut { .. }) = parser.current_token() {
         let param = FunctionOrMethodParam::parse(parser)?;
         params.push(param);
     }
@@ -327,7 +327,7 @@ fn parse_function_ptr_type(
         params.append(&mut subsequent_params.unwrap())
     };
 
-    match &parser.current_token() {
+    match parser.current_token() {
         Some(Token::RParen { .. }) => {
             parser.next_token();
         }
@@ -342,7 +342,7 @@ fn parse_function_ptr_type(
         }
     }
 
-    let return_type_opt = if let Some(Token::ThinArrow { .. }) = &parser.current_token() {
+    let return_type_opt = if let Some(Token::ThinArrow { .. }) = parser.current_token() {
         parser.next_token();
 
         if parser.current_token().is_some() {
@@ -373,14 +373,14 @@ fn parse_function_ptr_type(
 fn parse_array_type(parser: &mut Parser) -> Result<Type, ErrorsEmitted> {
     let ty = Type::parse(parser)?;
 
-    if let Some(Token::Semicolon { .. }) = &parser.current_token() {
+    if let Some(Token::Semicolon { .. }) = parser.current_token() {
         parser.next_token();
     } else {
         parser.log_unexpected_token("`;`");
     }
 
-    let num_elements = match &parser.next_token() {
-        Some(Token::UIntLiteral { value, .. }) => Ok(*value),
+    let num_elements = match parser.next_token() {
+        Some(Token::UIntLiteral { value, .. }) => Ok(value),
         Some(Token::EOF) | None => {
             parser.log_unexpected_eoi();
             Err(ErrorsEmitted)
@@ -391,7 +391,7 @@ fn parse_array_type(parser: &mut Parser) -> Result<Type, ErrorsEmitted> {
         }
     }?;
 
-    match &parser.current_token() {
+    match parser.current_token() {
         Some(Token::RBracket { .. }) => {
             parser.next_token();
 
@@ -412,10 +412,10 @@ fn parse_array_type(parser: &mut Parser) -> Result<Type, ErrorsEmitted> {
 }
 
 fn parse_tuple_type(parser: &mut Parser) -> Result<Type, ErrorsEmitted> {
-    if let Some(Token::RParen { .. }) = &parser.current_token() {
+    if let Some(Token::RParen { .. }) = parser.current_token() {
         parser.next_token();
         Ok(Type::UnitType(Unit))
-    } else if let Some(Token::Comma { .. }) = &parser.peek_ahead_by(1) {
+    } else if let Some(Token::Comma { .. }) = parser.peek_ahead_by(1) {
         let open_delimiter = Delimiter::LParen {
             position: Position::new(parser.current - 1, &parser.stream.span().input()),
         };
@@ -433,7 +433,7 @@ fn parse_tuple_type(parser: &mut Parser) -> Result<Type, ErrorsEmitted> {
     } else {
         let ty = Type::parse(parser)?;
 
-        match &parser.current_token() {
+        match parser.current_token() {
             Some(Token::RParen { .. }) => {
                 parser.next_token();
                 Ok(Type::GroupedType(Box::new(ty)))

--- a/src/parser/visibility.rs
+++ b/src/parser/visibility.rs
@@ -9,18 +9,18 @@ use super::Parser;
 
 impl Visibility {
     pub(crate) fn visibility(parser: &mut Parser) -> Result<Visibility, ErrorsEmitted> {
-        match parser.current_token().as_ref() {
+        match parser.current_token() {
             Some(Token::Pub { .. }) => {
                 parser.next_token();
 
-                match parser.current_token().as_ref() {
+                match parser.current_token() {
                     Some(Token::LParen { .. }) => {
                         let open_paren = Delimiter::LParen {
                             position: Position::new(parser.current, &parser.stream.span().input()),
                         };
                         parser.next_token();
 
-                        let kw_package = match parser.current_token().as_ref() {
+                        let kw_package = match parser.current_token() {
                             Some(Token::Package { .. }) => {
                                 parser.next_token();
                                 Ok(Keyword::Package)


### PR DESCRIPTION
Update `current_token()` function to return `Option<&Token>` instead of `Option<Token>`. 

Idea behind this: `current_token()` is mostly used in a read-only capacity, so it makes sense to return a borrowed `Token` instead of an owned one, which would have to be cloned within the function as `parser.stream.tokens().get()` returns an `Option<&Token>`.